### PR TITLE
Add node's benchmarks and Makefile for running them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# set ZONE=yes to run bench with zones
+
+bench-net:
+	node benchmark/common.js net
+
+bench-tls: 
+	node benchmark/common.js tls
+
+bench-http: 
+	node benchmark/common.js http
+
+bench-fs: 
+	node benchmark/common.js fs
+
+bench-vanilla: bench-net bench-http bench-fs bench-tls
+
+bench-zones: 
+	export ZONE=yes && make bench-vanilla
+
+bench: bench-zones bench-vanilla
+
+.PHONY: bench bench-zones bench-vanilla

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -1,0 +1,210 @@
+var assert = require('assert');
+var path = require('path');
+var silent = +process.env.NODE_BENCH_SILENT;
+var PATH_TO_ZONE_MODULE = path.join(__dirname, '..');
+var useZones = process.env.ZONE;
+
+exports.PORT = process.env.PORT || 12346;
+
+// use zones?
+if(useZones) {
+  require(PATH_TO_ZONE_MODULE);
+}
+
+// If this is the main module, then run the benchmarks
+if (module === require.main) {
+  var type = process.argv[2];
+  if (!type) {
+    console.error('usage:\n ./node benchmark/common.js <type>');
+    process.exit(1);
+  }
+
+  var fs = require('fs');
+  var dir = path.join(__dirname, type);
+  var tests = fs.readdirSync(dir);
+  var spawn = require('child_process').spawn;
+
+  runBenchmarks();
+
+  function runBenchmarks() {
+    var test = tests.shift();
+    if (!test)
+      return;
+
+    if (test.match(/^[\._]/))
+      return process.nextTick(runBenchmarks);
+
+    console.error(type + '/' + test);
+    test = path.resolve(dir, test);
+
+    var child = spawn(process.execPath, [ test ], { stdio: 'inherit' });
+    child.on('close', function(code) {
+      if (code)
+        process.exit(code);
+      else {
+        console.log('');
+        runBenchmarks();
+      }
+    });
+  }
+}
+
+exports.createBenchmark = function(fn, options) {
+  return new Benchmark(fn, options);
+};
+
+function Benchmark(fn, options) {
+  this.fn = fn;
+  this.options = options;
+  this.config = parseOpts(options);
+  this._name = require.main.filename.split(/benchmark[\/\\]/).pop();
+  this._start = [0,0];
+  this._started = false;
+  var self = this;
+  process.nextTick(function() {
+    self._run();
+  });
+}
+
+// benchmark an http server.
+Benchmark.prototype.http = function(p, args, cb) {
+  var self = this;
+  var wrk = path.resolve(__dirname, '..', 'tools', 'wrk', 'wrk');
+  var regexp = /Requests\/sec:[ \t]+([0-9\.]+)/;
+  var spawn = require('child_process').spawn;
+  var url = 'http://127.0.0.1:' + exports.PORT + p;
+
+  args = args.concat(url);
+
+  var out = '';
+  var child = spawn(wrk, args);
+
+  child.stdout.setEncoding('utf8');
+
+  child.stdout.on('data', function(chunk) {
+    out += chunk;
+  });
+
+  child.on('close', function(code) {
+    if (cb)
+      cb(code);
+
+    if (code) {
+      console.error('wrk failed with ' + code);
+      process.exit(code)
+    }
+    var m = out.match(regexp);
+    var qps = m && +m[1];
+    if (!qps) {
+      console.error('%j', out);
+      console.error('wrk produced strange output');
+      process.exit(1);
+    }
+    self.report(+qps);
+  });
+};
+
+Benchmark.prototype._run = function() {
+  if (this.config)
+    return this.fn(this.config);
+
+  // one more more options weren't set.
+  // run with all combinations
+  var main = require.main.filename;
+  var settings = [];
+  var queueLen = 1;
+  var options = this.options;
+
+  var queue = Object.keys(options).reduce(function(set, key) {
+    var vals = options[key];
+    assert(Array.isArray(vals));
+
+    // match each item in the set with each item in the list
+    var newSet = new Array(set.length * vals.length);
+    var j = 0;
+    set.forEach(function(s) {
+      vals.forEach(function(val) {
+        newSet[j++] = s.concat(key + '=' + val);
+      });
+    });
+    return newSet;
+  }, [[main]]);
+
+  var spawn = require('child_process').spawn;
+  var node = process.execPath;
+  var i = 0;
+  function run() {
+    var argv = queue[i++];
+    if (!argv)
+      return;
+    var child = spawn(node, argv, { stdio: 'inherit' });
+    child.on('close', function(code, signal) {
+      if (code)
+        console.error('child process exited with code ' + code);
+      else
+        run();
+    });
+  }
+  run();
+};
+
+function parseOpts(options) {
+  // verify that there's an option provided for each of the options
+  // if they're not *all* specified, then we return null.
+  var keys = Object.keys(options);
+  var num = keys.length;
+  var conf = {};
+  for (var i = 2; i < process.argv.length; i++) {
+    var m = process.argv[i].match(/^(.+)=(.+)$/);
+    if (!m || !m[1] || !m[2] || !options[m[1]])
+      return null;
+    else {
+      conf[m[1]] = isFinite(m[2]) ? +m[2] : m[2]
+      num--;
+    }
+  }
+  // still go ahead and set whatever WAS set, if it was.
+  if (num !== 0) {
+    Object.keys(conf).forEach(function(k) {
+      options[k] = [conf[k]];
+    });
+  }
+  return num === 0 ? conf : null;
+};
+
+Benchmark.prototype.start = function() {
+  if (this._started)
+    throw new Error('Called start more than once in a single benchmark');
+  this._started = true;
+  this._start = process.hrtime();
+};
+
+Benchmark.prototype.end = function(operations) {
+  var elapsed = process.hrtime(this._start);
+  if (!this._started)
+    throw new Error('called end without start');
+  if (typeof operations !== 'number')
+    throw new Error('called end() without specifying operation count');
+  var time = elapsed[0] + elapsed[1]/1e9;
+  var rate = operations/time;
+  this.report(rate);
+};
+
+Benchmark.prototype.report = function(value) {
+  var heading = this.getHeading();
+  if (!silent)
+    console.log(
+      '%s: %s (%s)',
+      heading,
+      value.toPrecision(5),
+      useZones ? 'w/ zones' : 'zones disabled'
+    );
+  process.exit(0);
+};
+
+Benchmark.prototype.getHeading = function() {
+  var conf = this.config;
+  return this._name + ' ' + Object.keys(conf).map(function(key) {
+    return key + '=' + conf[key];
+  }).join(' ');
+}

--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -1,0 +1,138 @@
+var usage = 'node benchmark/compare.js <node-binary1> <node-binary2> [--html] [--red|-r] [--green|-g]';
+
+var show = 'both';
+var nodes = [];
+var html = false;
+
+for (var i = 2; i < process.argv.length; i++) {
+  var arg = process.argv[i];
+  switch (arg) {
+    case '--red': case '-r':
+      show = show === 'green' ? 'both' : 'red';
+      break;
+    case '--green': case '-g':
+      show = show === 'red' ? 'both' : 'green';
+      break;
+    case '--html':
+      html = true;
+      break;
+    case '-h': case '-?': case '--help':
+      console.log(usage);
+      process.exit(0);
+    default:
+      nodes.push(arg);
+      break;
+  }
+}
+
+if (!html) {
+  var start = '';
+  var green = '\033[1;32m';
+  var red = '\033[1;31m';
+  var reset = '\033[m';
+  var end = '';
+} else {
+  var start = '<pre style="background-color:#333;color:#eee">';
+  var green = '<span style="background-color:#0f0;color:#000">';
+  var red = '<span style="background-color:#f00;color:#fff">';
+  var reset = '</span>';
+  var end = '</pre>';
+}
+
+var runBench = process.env.NODE_BENCH || 'bench';
+
+if (nodes.length !== 2)
+	return console.error('usage:\n  %s', usage);
+
+var spawn = require('child_process').spawn;
+var results = {};
+var n = 2;
+
+run();
+
+function run() {
+  if (n === 0)
+		return compare();
+
+  n--;
+
+	var node = nodes[n];
+  console.error('running %s', node);
+	var env = {};
+  for (var i in process.env)
+    env[i] = process.env[i];
+  env.NODE = node;
+	var child = spawn('make', [ runBench ], { env: env });
+
+	var out = '';
+	child.stdout.setEncoding('utf8');
+	child.stdout.on('data', function(c) {
+		out += c;
+	});
+
+  child.stderr.pipe(process.stderr);
+
+	child.on('close', function(code) {
+		if (code) {
+			console.error('%s exited with code=%d', node, code);
+			process.exit(code);
+		} else {
+			out.trim().split(/\r?\n/).forEach(function(line) {
+        line = line.trim();
+        if (!line)
+          return;
+
+				var s = line.split(':');
+				var num = +s.pop();
+				if (!num && num !== 0)
+          return
+
+				line = s.join(':');
+				var res = results[line] = results[line] || {};
+				res[node] = num;
+			});
+
+			run();
+		}
+	});
+}
+
+function compare() {
+	// each result is an object with {"foo.js arg=bar":12345,...}
+	// compare each thing, and show which node did the best.
+  // node[0] is shown in green, node[1] shown in red.
+  var maxLen = -Infinity;
+  var util = require('util');
+  console.log(start);
+
+	Object.keys(results).map(function(bench) {
+    var res = results[bench];
+    var n0 = res[nodes[0]];
+    var n1 = res[nodes[1]];
+
+    var pct = ((n0 - n1) / n1 * 100).toFixed(2);
+
+    var g = n0 > n1 ? green : '';
+    var r = n0 > n1 ? '' : red;
+    var c = r || g;
+
+    if (show === 'green' && !g || show === 'red' && !r)
+      return;
+
+    var r0 = util.format('%s%s: %d%s', g, nodes[0], n0, reset);
+    var r1 = util.format('%s%s: %d%s', r, nodes[1], n1, reset);
+    var pct = c + pct + '%' + reset;
+    var l = util.format('%s: %s %s', bench, r0, r1);
+    maxLen = Math.max(l.length + pct.length, maxLen);
+    return [l, pct];
+  }).filter(function(l) {
+    return l;
+  }).forEach(function(line) {
+    var l = line[0];
+    var pct = line[1];
+    var dotLen = maxLen - l.length - pct.length + 2;
+    var dots = ' ' + new Array(Math.max(0, dotLen)).join('.') + ' ';
+    console.log(l + dots + pct);
+  });
+  console.log(end);
+}

--- a/benchmark/fs-write-stream-throughput.js
+++ b/benchmark/fs-write-stream-throughput.js
@@ -1,0 +1,96 @@
+
+// If there are no args, then this is the root.  Run all the benchmarks!
+if (!process.argv[2])
+  parent();
+else
+  runTest(+process.argv[2], +process.argv[3], process.argv[4]);
+
+function parent() {
+  var types = [ 'string', 'buffer' ];
+  var durs = [ 1, 5 ];
+  var sizes = [ 1, 10, 100, 2048, 10240 ];
+  var queue = [];
+  types.forEach(function(t) {
+    durs.forEach(function(d) {
+      sizes.forEach(function(s) {
+        queue.push([__filename, d, s, t]);
+      });
+    });
+  });
+
+  var spawn = require('child_process').spawn;
+  var node = process.execPath;
+
+  run();
+
+  function run() {
+    var args = queue.shift();
+    if (!args)
+      return;
+    var child = spawn(node, args, { stdio: 'inherit' });
+    child.on('close', function(code, signal) {
+      if (code)
+        throw new Error('Benchmark failed: ' + args.slice(1));
+      run();
+    });
+  }
+}
+
+function runTest(dur, size, type) {
+  if (type !== 'string')
+    type = 'buffer';
+  switch (type) {
+    case 'string':
+      var chunk = new Array(size + 1).join('a');
+      break;
+    case 'buffer':
+      var chunk = new Buffer(size);
+      chunk.fill('a');
+      break;
+  }
+
+  var writes = 0;
+  var fs = require('fs');
+  try { fs.unlinkSync('write_stream_throughput'); } catch (e) {}
+
+  var start
+  var end;
+  function done() {
+    var time = end[0] + end[1]/1E9;
+    var written = fs.statSync('write_stream_throughput').size / 1024;
+    var rate = (written / time).toFixed(2);
+    console.log('fs_write_stream_dur_%d_size_%d_type_%s: %d',
+                dur, size, type, rate);
+
+    try { fs.unlinkSync('write_stream_throughput'); } catch (e) {}
+  }
+
+  var f = require('fs').createWriteStream('write_stream_throughput');
+  f.on('drain', write);
+  f.on('open', write);
+  f.on('close', done);
+
+  // streams2 fs.WriteStreams will let you send a lot of writes into the
+  // buffer before returning false, so capture the *actual* end time when
+  // all the bytes have been written to the disk, indicated by 'finish'
+  f.on('finish', function() {
+    end = process.hrtime(start);
+  });
+
+  var ending = false;
+  function write() {
+    // don't try to write after we end, even if a 'drain' event comes.
+    // v0.8 streams are so sloppy!
+    if (ending)
+      return;
+
+    start = start || process.hrtime();
+    while (false !== f.write(chunk));
+    end = process.hrtime(start);
+
+    if (end[0] >= dur) {
+      ending = true;
+      f.end();
+    }
+  }
+}

--- a/benchmark/fs/read-stream-throughput.js
+++ b/benchmark/fs/read-stream-throughput.js
@@ -1,0 +1,87 @@
+// test the througput of the fs.WriteStream class.
+
+var path = require('path');
+var common = require('../common.js');
+var filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
+var fs = require('fs');
+var filesize = 1000 * 1024 * 1024;
+var assert = require('assert');
+
+var type, encoding, size;
+
+var bench = common.createBenchmark(main, {
+  type: ['buf', 'asc', 'utf'],
+  size: [1024, 4096, 65535, 1024*1024]
+});
+
+function main(conf) {
+  type = conf.type;
+  size = +conf.size;
+
+  switch (type) {
+    case 'buf':
+      encoding = null;
+      break;
+    case 'asc':
+      encoding = 'ascii';
+      break;
+    case 'utf':
+      encoding = 'utf8';
+      break;
+    default:
+      throw new Error('invalid type');
+  }
+
+  makeFile(runTest);
+}
+
+function runTest() {
+  assert(fs.statSync(filename).size === filesize);
+  var rs = fs.createReadStream(filename, {
+    bufferSize: size,
+    encoding: encoding
+  });
+
+  rs.on('open', function() {
+    bench.start();
+  });
+
+  var bytes = 0;
+  rs.on('data', function(chunk) {
+    bytes += chunk.length;
+  });
+
+  rs.on('end', function() {
+    try { fs.unlinkSync(filename); } catch (e) {}
+    // MB/sec
+    bench.end(bytes / (1024 * 1024));
+  });
+}
+
+function makeFile() {
+  var buf = new Buffer(filesize / 1024);
+  if (encoding === 'utf8') {
+    // ü
+    for (var i = 0; i < buf.length; i++) {
+      buf[i] = i % 2 === 0 ? 0xC3 : 0xBC;
+    }
+  } else if (encoding === 'ascii') {
+    buf.fill('a');
+  } else {
+    buf.fill('x');
+  }
+
+  try { fs.unlinkSync(filename); } catch (e) {}
+  var w = 1024;
+  var ws = fs.createWriteStream(filename);
+  ws.on('close', runTest);
+  ws.on('drain', write);
+  write();
+  function write() {
+    do {
+      w--;
+    } while (false !== ws.write(buf) && w > 0);
+    if (w === 0)
+      ws.end();
+  }
+}

--- a/benchmark/fs/readfile.js
+++ b/benchmark/fs/readfile.js
@@ -1,0 +1,48 @@
+// Call fs.readFile over and over again really fast.
+// Then see how many times it got called.
+// Yes, this is a silly benchmark.  Most benchmarks are silly.
+
+var path = require('path');
+var common = require('../common.js');
+var filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
+var fs = require('fs');
+
+var bench = common.createBenchmark(main, {
+  dur: [5],
+  len: [1024, 16 * 1024 * 1024],
+  concurrent: [1, 10]
+});
+
+function main(conf) {
+  var len = +conf.len;
+  try { fs.unlinkSync(filename); } catch (e) {}
+  var data = new Buffer(len);
+  data.fill('x');
+  fs.writeFileSync(filename, data);
+  data = null;
+
+  var reads = 0;
+  bench.start();
+  setTimeout(function() {
+    bench.end(reads);
+    try { fs.unlinkSync(filename); } catch (e) {}
+  }, +conf.dur * 1000);
+
+  function read() {
+    fs.readFile(filename, afterRead);
+  }
+
+  function afterRead(er, data) {
+    if (er)
+      throw er;
+
+    if (data.length !== len)
+      throw new Error('wrong number of bytes returned');
+
+    reads++;
+    read();
+  }
+
+  var cur = +conf.concurrent;
+  while (cur--) read();
+}

--- a/benchmark/fs/write-stream-throughput.js
+++ b/benchmark/fs/write-stream-throughput.js
@@ -1,0 +1,78 @@
+// test the througput of the fs.WriteStream class.
+
+var path = require('path');
+var common = require('../common.js');
+var filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
+var fs = require('fs');
+
+var bench = common.createBenchmark(main, {
+  dur: [5],
+  type: ['buf', 'asc', 'utf'],
+  size: [2, 1024, 65535, 1024 * 1024]
+});
+
+function main(conf) {
+  var dur = +conf.dur;
+  var type = conf.type;
+  var size = +conf.size;
+  var encoding;
+
+  var chunk;
+  switch (type) {
+    case 'buf':
+      chunk = new Buffer(size);
+      chunk.fill('b');
+      break;
+    case 'asc':
+      chunk = new Array(size + 1).join('a');
+      encoding = 'ascii';
+      break;
+    case 'utf':
+      chunk = new Array(Math.ceil(size/2) + 1).join('ü');
+      encoding = 'utf8';
+      break;
+    default:
+      throw new Error('invalid type');
+  }
+
+  try { fs.unlinkSync(filename); } catch (e) {}
+
+  var started = false;
+  var ending = false;
+  var ended = false;
+  setTimeout(function() {
+    ending = true;
+    f.end();
+  }, dur * 1000);
+
+  var f = fs.createWriteStream(filename);
+  f.on('drain', write);
+  f.on('open', write);
+  f.on('close', done);
+  f.on('finish', function() {
+    ended = true;
+    var written = fs.statSync(filename).size / 1024;
+    try { fs.unlinkSync(filename); } catch (e) {}
+    bench.end(written / 1024);
+  });
+
+
+  function write() {
+    // don't try to write after we end, even if a 'drain' event comes.
+    // v0.8 streams are so sloppy!
+    if (ending)
+      return;
+
+    if (!started) {
+      started = true;
+      bench.start();
+    }
+
+    while (false !== f.write(chunk, encoding));
+  }
+
+  function done() {
+    if (!ended)
+      f.emit('finish');
+  }
+}

--- a/benchmark/http/cluster.js
+++ b/benchmark/http/cluster.js
@@ -1,0 +1,38 @@
+var common = require('../common.js');
+var PORT = common.PORT;
+
+var cluster = require('cluster');
+if (cluster.isMaster) {
+  var bench = common.createBenchmark(main, {
+    // unicode confuses ab on os x.
+    type: ['bytes', 'buffer'],
+    length: [4, 1024, 102400],
+    c: [50, 500]
+  });
+} else {
+  require('../http_simple.js');
+}
+
+function main(conf) {
+  process.env.PORT = PORT;
+  var workers = 0;
+  var w1 = cluster.fork();
+  var w2 = cluster.fork();
+
+  cluster.on('listening', function() {
+    workers++;
+    if (workers < 2)
+      return;
+
+    setTimeout(function() {
+      var path = '/' + conf.type + '/' + conf.length;
+      var args = ['-r', '-t', 5, '-c', conf.c, '-k'];
+      var args = ['-r', 5000, '-t', 8, '-c', conf.c];
+
+      bench.http(path, args, function() {
+        w1.destroy();
+        w2.destroy();
+      });
+    }, 100);
+  });
+}

--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -1,0 +1,23 @@
+var common = require('../common.js');
+var PORT = common.PORT;
+
+var bench = common.createBenchmark(main, {
+  // unicode confuses ab on os x.
+  type: ['bytes', 'buffer'],
+  length: [4, 1024, 102400],
+  c: [50, 500]
+});
+
+function main(conf) {
+  process.env.PORT = PORT;
+  var spawn = require('child_process').spawn;
+  var server = require('../http_simple.js');
+  setTimeout(function() {
+    var path = '/' + conf.type + '/' + conf.length; //+ '/' + conf.chunks;
+    var args = ['-r', 5000, '-t', 8, '-c', conf.c];
+
+    bench.http(path, args, function() {
+      server.close();
+    });
+  }, 2000);
+}

--- a/benchmark/http_bench.js
+++ b/benchmark/http_bench.js
@@ -1,0 +1,127 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var spawn = require('child_process').spawn;
+var cluster = require('cluster');
+var http = require('http');
+
+var options = {
+  mode: 'master',
+  host: '127.0.0.1',
+  port: 22344,
+  path: '/',
+  servers: 1,
+  clients: 1
+};
+
+for (var i = 2; i < process.argv.length; ++i) {
+  var args = process.argv[i].split('=', 2);
+  var key = args[0];
+  var val = args[1];
+  options[key] = val;
+}
+
+switch (options.mode) {
+case 'master': startMaster(); break;
+case 'server': startServer(); break;
+case 'client': startClient(); break;
+default: throw new Error('Bad mode: ' + options.mode);
+}
+
+process.title = 'http_bench[' + options.mode + ']';
+
+// monkey-patch the log functions so they include name + pid
+console.log = patch(console.log);
+console.trace = patch(console.trace);
+console.error = patch(console.error);
+
+function patch(fun) {
+  var prefix = process.title + '[' + process.pid + '] ';
+  return function() {
+    var args = Array.prototype.slice.call(arguments);
+    args[0] = prefix + args[0];
+    return fun.apply(console, args);
+  };
+}
+
+function startMaster() {
+  if (!cluster.isMaster) return startServer();
+
+  for (var i = ~~options.servers; i > 0; --i) cluster.fork();
+
+  for (var i = ~~options.clients; i > 0; --i) {
+    var cp = spawn(process.execPath, [__filename, 'mode=client']);
+    cp.stdout.pipe(process.stdout);
+    cp.stderr.pipe(process.stderr);
+  }
+}
+
+function startServer() {
+  http.createServer(onRequest).listen(options.port, options.host);
+
+  var body = Array(1024).join('x');
+  var headers = {'Content-Length': '' + body.length};
+
+  function onRequest(req, res) {
+    req.on('error', onError);
+    res.on('error', onError);
+    res.writeHead(200, headers);
+    res.end(body);
+  }
+
+  function onError(err) {
+    console.error(err.stack);
+  }
+}
+
+function startClient() {
+  // send off a bunch of concurrent requests
+  // TODO make configurable
+  sendRequest();
+  sendRequest();
+
+  function sendRequest() {
+    var req = http.request(options, onConnection);
+    req.on('error', onError);
+    req.end();
+  }
+
+  // add a little back-off to prevent EADDRNOTAVAIL errors, it's pretty easy
+  // to exhaust the available port range
+  function relaxedSendRequest() {
+    setTimeout(sendRequest, 1);
+  }
+
+  function onConnection(res) {
+    res.on('error', onError);
+    res.on('data', onData);
+    res.on('end', relaxedSendRequest);
+  }
+
+  function onError(err) {
+    console.error(err.stack);
+    relaxedSendRequest();
+  }
+
+  function onData(data) {
+    // this space intentionally left blank
+  }
+}

--- a/benchmark/http_server_lag.js
+++ b/benchmark/http_server_lag.js
@@ -1,0 +1,13 @@
+var http = require('http');
+var port = parseInt(process.env.PORT, 10) || 8000;
+var defaultLag = parseInt(process.argv[2], 10) || 100;
+
+http.createServer(function(req, res) {
+  res.writeHead(200, { 'content-type': 'text/plain',
+                       'content-length': '2' });
+
+  var lag = parseInt(req.url.split("/").pop(), 10) || defaultLag;
+  setTimeout(function() {
+    res.end('ok');
+  }, lag);
+}).listen(port, 'localhost');

--- a/benchmark/http_simple.js
+++ b/benchmark/http_simple.js
@@ -1,0 +1,120 @@
+var path = require('path'),
+    exec = require('child_process').exec,
+    http = require('http');
+
+var port = parseInt(process.env.PORT || 8000);
+
+var fixed = makeString(20 * 1024, 'C'),
+    storedBytes = {},
+    storedBuffer = {},
+    storedUnicode = {};
+
+var useDomains = process.env.NODE_USE_DOMAINS;
+
+// set up one global domain.
+if (useDomains) {
+  var domain = require('domain');
+  var gdom = domain.create();
+  gdom.on('error', function(er) {
+    console.error('Error on global domain', er);
+    throw er;
+  });
+  gdom.enter();
+}
+
+var server = module.exports = http.createServer(function (req, res) {
+  if (useDomains) {
+    var dom = domain.create();
+    dom.add(req);
+    dom.add(res);
+  }
+
+  var commands = req.url.split('/');
+  var command = commands[1];
+  var body = '';
+  var arg = commands[2];
+  var n_chunks = parseInt(commands[3], 10);
+  var status = 200;
+
+  if (command == 'bytes') {
+    var n = ~~arg;
+    if (n <= 0)
+      throw new Error('bytes called with n <= 0')
+    if (storedBytes[n] === undefined) {
+      storedBytes[n] = makeString(n, 'C');
+    }
+    body = storedBytes[n];
+
+  } else if (command == 'buffer') {
+    var n = ~~arg;
+    if (n <= 0)
+      throw new Error('buffer called with n <= 0');
+    if (storedBuffer[n] === undefined) {
+      storedBuffer[n] = new Buffer(n);
+      for (var i = 0; i < n; i++) {
+        storedBuffer[n][i] = 'C'.charCodeAt(0);
+      }
+    }
+    body = storedBuffer[n];
+
+  } else if (command == 'unicode') {
+    var n = ~~arg;
+    if (n <= 0)
+      throw new Error('unicode called with n <= 0');
+    if (storedUnicode[n] === undefined) {
+      storedUnicode[n] = makeString(n, '\u263A');
+    }
+    body = storedUnicode[n];
+
+  } else if (command == 'quit') {
+    res.connection.server.close();
+    body = 'quitting';
+
+  } else if (command == 'fixed') {
+    body = fixed;
+
+  } else if (command == 'echo') {
+    res.writeHead(200, { 'Content-Type': 'text/plain',
+                         'Transfer-Encoding': 'chunked' });
+    req.pipe(res);
+    return;
+
+  } else {
+    status = 404;
+    body = 'not found\n';
+  }
+
+  // example: http://localhost:port/bytes/512/4
+  // sends a 512 byte body in 4 chunks of 128 bytes
+  if (n_chunks > 0) {
+    res.writeHead(status, { 'Content-Type': 'text/plain',
+                            'Transfer-Encoding': 'chunked' });
+    // send body in chunks
+    var len = body.length;
+    var step = Math.floor(len / n_chunks) || 1;
+
+    for (var i = 0, n = (n_chunks - 1); i < n; ++i) {
+      res.write(body.slice(i * step, i * step + step));
+    }
+    res.end(body.slice((n_chunks - 1) * step));
+  } else {
+    var content_length = body.length.toString();
+
+    res.writeHead(status, { 'Content-Type': 'text/plain',
+                            'Content-Length': content_length });
+    res.end(body);
+  }
+});
+
+function makeString(size, c) {
+  var s = '';
+  while (s.length < size) {
+    s += c;
+  }
+  return s;
+}
+
+server.listen(port, function () {
+  if (module === require.main)
+    console.error('Listening at http://127.0.0.1:'+port+'/');
+});

--- a/benchmark/http_simple.rb
+++ b/benchmark/http_simple.rb
@@ -1,0 +1,95 @@
+DIR = File.dirname(__FILE__)
+
+def fib(n)
+  return 1 if n <= 1
+  fib(n-1) + fib(n-2)
+end
+
+def wait(seconds)
+  n = (seconds / 0.01).to_i
+  n.times do
+    sleep(0.01)
+    #File.read(DIR + '/yahoo.html')
+  end
+end
+
+class SimpleApp
+  @@responses = {}
+
+  def initialize
+    @count = 0
+  end
+
+  def deferred?(env)
+    false
+  end
+
+  def call(env)
+    path = env['PATH_INFO'] || env['REQUEST_URI']
+    commands = path.split('/')
+
+    @count += 1
+    if commands.include?('periodical_activity') and @count % 10 != 1
+      return [200, {'Content-Type'=>'text/plain'}, "quick response!\r\n"]
+    end
+
+    if commands.include?('fibonacci')
+      n = commands.last.to_i
+      raise "fibonacci called with n <= 0" if n <= 0
+      body = (1..n).to_a.map { |i| fib(i).to_s }.join(' ')
+      status = 200
+
+    elsif commands.include?('wait')
+      n = commands.last.to_f
+      raise "wait called with n <= 0" if n <= 0
+      wait(n)
+      body = "waited about #{n} seconds"
+      status = 200
+
+    elsif commands.include?('bytes')
+      n = commands.last.to_i
+      raise "bytes called with n <= 0" if n <= 0
+      body = @@responses[n] || "C"*n
+      status = 200
+
+    elsif commands.include?('fixed')
+      n = 20 * 1024;
+      body = @@responses[n] || "C"*n
+      status = 200
+
+    elsif commands.include?('test_post_length')
+      input_body = ""
+      while chunk = env['rack.input'].read(512)
+        input_body << chunk
+      end
+      if env['CONTENT_LENGTH'].to_i == input_body.length
+        body = "Content-Length matches input length"
+        status = 200
+      else
+        body = "Content-Length doesn't matches input length!
+          content_length = #{env['CONTENT_LENGTH'].to_i}
+          input_body.length = #{input_body.length}"
+        status = 500
+      end
+    else
+      status = 404
+      body = "Undefined url"
+    end
+
+    body += "\r\n"
+    headers = {'Content-Type' => 'text/plain', 'Content-Length' => body.length.to_s }
+    [status, headers, [body]]
+  end
+end
+
+
+if $0 == __FILE__
+  #require DIR + '/../lib/ebb'
+  require 'rubygems'
+  require 'rack'
+  require 'thin'
+  require 'ebb'
+#  Rack::Handler::Mongrel.run(SimpleApp.new, :Port => 8000)
+  Thin::Server.start("0.0.0.0", 8000, SimpleApp.new)
+#  Ebb::start_server(SimpleApp.new, :port => 8000)
+end

--- a/benchmark/http_simple_auto.js
+++ b/benchmark/http_simple_auto.js
@@ -1,0 +1,127 @@
+//
+// Usage:
+//   node benchmark/http_simple_auto.js <args> <target>
+//
+// Where:
+//   <args>   Arguments to pass to `ab`.
+//   <target> Target to benchmark, e.g. `bytes/1024` or `buffer/8192`.
+//
+
+var path = require("path");
+var http = require("http");
+var spawn = require("child_process").spawn;
+
+var port = parseInt(process.env.PORT || 8000);
+
+var fixed = ""
+for (var i = 0; i < 20*1024; i++) {
+  fixed += "C";
+}
+
+var stored = {};
+var storedBuffer = {};
+
+var server = http.createServer(function (req, res) {
+  var commands = req.url.split("/");
+  var command = commands[1];
+  var body = "";
+  var arg = commands[2];
+  var n_chunks = parseInt(commands[3], 10);
+  var status = 200;
+
+  if (command == "bytes") {
+    var n = parseInt(arg, 10)
+    if (n <= 0)
+      throw "bytes called with n <= 0"
+    if (stored[n] === undefined) {
+      stored[n] = "";
+      for (var i = 0; i < n; i++) {
+        stored[n] += "C"
+      }
+    }
+    body = stored[n];
+
+  } else if (command == "buffer") {
+    var n = parseInt(arg, 10)
+    if (n <= 0) throw new Error("bytes called with n <= 0");
+    if (storedBuffer[n] === undefined) {
+      storedBuffer[n] = new Buffer(n);
+      for (var i = 0; i < n; i++) {
+        storedBuffer[n][i] = "C".charCodeAt(0);
+      }
+    }
+    body = storedBuffer[n];
+
+  } else if (command == "quit") {
+    res.connection.server.close();
+    body = "quitting";
+
+  } else if (command == "fixed") {
+    body = fixed;
+
+  } else if (command == "echo") {
+    res.writeHead(200, { "Content-Type": "text/plain",
+                         "Transfer-Encoding": "chunked" });
+    req.pipe(res);
+    return;
+
+  } else {
+    status = 404;
+    body = "not found\n";
+  }
+
+  // example: http://localhost:port/bytes/512/4
+  // sends a 512 byte body in 4 chunks of 128 bytes
+  if (n_chunks > 0) {
+    res.writeHead(status, { "Content-Type": "text/plain",
+                            "Transfer-Encoding": "chunked" });
+    // send body in chunks
+    var len = body.length;
+    var step = Math.floor(len / n_chunks) || 1;
+
+    for (var i = 0, n = (n_chunks - 1); i < n; ++i) {
+      res.write(body.slice(i * step, i * step + step));
+    }
+    res.end(body.slice((n_chunks - 1) * step));
+  } else {
+    var content_length = body.length.toString();
+
+    res.writeHead(status, { "Content-Type": "text/plain",
+                            "Content-Length": content_length });
+    res.end(body);
+  }
+
+});
+
+server.listen(port, function () {
+  var url = 'http://127.0.0.1:' + port + '/';
+
+  var n = process.argv.length - 1;
+  process.argv[n] = url + process.argv[n];
+
+  var cp = spawn('ab', process.argv.slice(2));
+  cp.stdout.pipe(process.stdout);
+  cp.stderr.pipe(process.stderr);
+  cp.on('exit', function() {
+    server.close();
+    process.nextTick(dump_mm_stats);
+  });
+});
+
+function dump_mm_stats() {
+  if (typeof gc != 'function') return;
+
+  var before = process.memoryUsage();
+  for (var i = 0; i < 10; ++i) gc();
+  var after = process.memoryUsage();
+  setTimeout(print_stats, 250); // give GC time to settle
+
+  function print_stats() {
+    console.log('\nBEFORE / AFTER GC');
+    ['rss', 'heapTotal', 'heapUsed'].forEach(function(key) {
+      var a = before[key] / (1024 * 1024);
+      var b = after[key] / (1024 * 1024);
+      console.log('%sM / %sM %s', a.toFixed(2), b.toFixed(2), key);
+    });
+  }
+}

--- a/benchmark/http_simple_bench.sh
+++ b/benchmark/http_simple_bench.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+SERVER=127.0.0.1
+PORT=${PORT:=8000}
+
+# You may want to configure your TCP settings to make many ports available
+# to node and ab. On macintosh use: 
+#   sudo sysctl -w net.inet.ip.portrange.first=32768
+#   sudo sysctl -w net.inet.tcp.msl=1000
+
+if [ ! -d benchmark/ ]; then
+  echo "Run this script from the node root directory"
+  exit 1
+fi
+
+if [ $SERVER == "127.0.0.1" ]; then
+  ./node benchmark/http_simple.js &
+  node_pid=$!
+  sleep 1
+fi
+
+date=`date "+%Y%m%d%H%M%S"`
+
+ab_hello_world() {
+  local type="$1"
+  local ressize="$2"
+  if [ $type == "string" ]; then 
+    local uri="bytes/$ressize"
+  else
+    local uri="buffer/$ressize"
+  fi
+
+
+  name="ab-hello-world-$type-$ressize"
+
+  dir=".benchmark_reports/$name/$rev/"
+  if [ ! -d $dir ]; then
+    mkdir -p $dir
+  fi
+
+  summary_fn="$dir/$date.summary"
+  data_fn="$dir/$date.data"
+
+  echo "Bench $name starts in 3 seconds..."
+  # let shit calm down
+  sleep 3
+
+  # hammer that as hard as it can for 10 seconds.
+  ab -g $data_fn -c 100 -t 10 http://$SERVER:$PORT/$uri > $summary_fn
+
+  # add our data about the server
+  echo >> $summary_fn
+  echo >> $summary_fn
+  echo "webserver-rev: $rev" >> $summary_fn
+  echo "webserver-uname: $uname" >> $summary_fn
+
+  grep Req $summary_fn 
+
+  echo "Summary: $summary_fn"
+  echo
+}
+
+# 1k
+ab_hello_world 'string' '1024'
+ab_hello_world 'buffer' '1024'
+
+# 100k 
+ab_hello_world 'string' '102400'
+ab_hello_world 'buffer' '102400'
+
+
+if [ ! -z $node_pid ]; then
+  kill -9 $node_pid
+fi

--- a/benchmark/http_simple_cluster.js
+++ b/benchmark/http_simple_cluster.js
@@ -1,0 +1,9 @@
+var cluster = require('cluster');
+var os = require('os');
+
+if (cluster.isMaster) {
+  console.log('master running on pid %d', process.pid);
+  for (var i = 0, n = os.cpus().length; i < n; ++i) cluster.fork();
+} else {
+  require(__dirname + '/http_simple.js');
+}

--- a/benchmark/idle_clients.js
+++ b/benchmark/idle_clients.js
@@ -1,0 +1,49 @@
+net = require('net');
+
+var errors = 0, connections = 0;
+
+var lastClose = 0;
+
+function connect () {
+  process.nextTick(function () {
+    var s = net.Stream();
+    var gotConnected = false;
+    s.connect(9000);
+
+    s.on('connect', function () {
+      gotConnected = true;
+      connections++;
+      connect();
+    });
+
+    s.on('close', function () {
+      if (gotConnected) connections--;
+      lastClose = new Date();
+    });
+
+    s.on('error', function () {
+      errors++;
+    });
+  });
+}
+
+connect();
+
+
+var oldConnections, oldErrors;
+
+// Try to start new connections every so often
+setInterval(connect, 5000);
+
+setInterval(function () {
+  if (oldConnections != connections) {
+    oldConnections = connections;
+    console.log("CLIENT %d connections: %d", process.pid, connections);
+  }
+
+  if (oldErrors != errors) {
+    oldErrors = errors;
+    console.log("CLIENT %d errors: %d", process.pid, errors);
+  }
+}, 1000);
+

--- a/benchmark/idle_server.js
+++ b/benchmark/idle_server.js
@@ -1,0 +1,31 @@
+net = require('net');
+connections = 0;
+
+var errors = 0;
+
+server = net.Server(function (socket) {
+
+  socket.on('error', function () {
+    errors++; 
+  });
+
+});
+
+//server.maxConnections = 128;
+
+server.listen(9000);
+
+var oldConnections, oldErrors;
+
+setInterval(function () {
+  if (oldConnections != server.connections) {
+    oldConnections = server.connections;
+    console.log("SERVER %d connections: %d", process.pid, server.connections);
+  }
+
+  if (oldErrors != errors) {
+    oldErrors = errors;
+    console.log("SERVER %d errors: %d", process.pid, errors);
+  }
+}, 1000);
+

--- a/benchmark/io.c
+++ b/benchmark/io.c
@@ -1,0 +1,123 @@
+/**
+ * gcc -o iotest io.c
+ */
+
+#include <assert.h>
+#include <unistd.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/time.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+ 
+static int c = 0;
+static int tsize = 1000 * 1048576;
+static const char* path = "/tmp/wt.dat";
+static char buf[65536];
+
+static uint64_t now(void) {
+  struct timeval tv;
+
+  if (gettimeofday(&tv, NULL))
+    abort();
+
+  return tv.tv_sec * 1000000ULL + tv.tv_usec;
+}
+
+static void writetest(int size, size_t bsize)
+{
+  int i;
+  uint64_t start, end;
+  double elapsed;
+  double mbps;
+
+  assert(bsize <= sizeof buf);
+
+  int fd = open(path, O_CREAT|O_WRONLY, 0644);
+  if (fd < 0) {
+    perror("open failed");
+    exit(254);
+  }
+
+  start = now();
+
+  for (i = 0; i < size; i += bsize) {
+    int rv = write(fd, buf, bsize);
+    if (rv < 0) {
+      perror("write failed");
+      exit(254);
+    }
+  }
+
+#ifndef NSYNC
+# ifdef __linux__
+  fdatasync(fd);
+# else
+  fsync(fd);
+# endif
+#endif /* SYNC */
+
+  close(fd);
+
+  end = now();
+  elapsed = (end - start) / 1e6;
+  mbps = ((tsize/elapsed)) / 1048576;
+
+  fprintf(stderr, "Wrote %d bytes in %03fs using %ld byte buffers: %03f\n", size, elapsed, bsize, mbps);
+}
+
+void readtest(int size, size_t bsize)
+{
+  int i;
+  uint64_t start, end;
+  double elapsed;
+  double mbps;
+
+  assert(bsize <= sizeof buf);
+
+  int fd = open(path, O_RDONLY, 0644);
+  if (fd < 0) {
+    perror("open failed");
+    exit(254);
+  }
+
+  start = now();
+
+  for (i = 0; i < size; i += bsize) {
+    int rv = read(fd, buf, bsize);
+    if (rv < 0) {
+      perror("write failed");
+      exit(254);
+    }
+  }
+  close(fd);
+
+  end = now();
+  elapsed = (end - start) / 1e6;
+  mbps = ((tsize/elapsed)) / 1048576;
+
+  fprintf(stderr, "Read %d bytes in %03fs using %ld byte buffers: %03fmB/s\n", size, elapsed, bsize, mbps);
+}
+
+void cleanup() {
+  unlink(path);
+}
+
+int main(int argc, char** argv)
+{
+  int i;
+  int bsizes[] = {1024, 4096, 8192, 16384, 32768, 65536, 0};
+
+  if (argc > 1) path = argv[1];
+
+  for (i = 0; bsizes[i] != 0; i++) {
+    writetest(tsize, bsizes[i]);
+  }
+  for (i = 0; bsizes[i] != 0; i++) {
+    readtest(tsize, bsizes[i]);
+  }
+  atexit(cleanup);
+  return 0;
+}

--- a/benchmark/net/net-c2s.js
+++ b/benchmark/net/net-c2s.js
@@ -1,0 +1,112 @@
+// test the speed of .pipe() with sockets
+
+var common = require('../common.js');
+var PORT = common.PORT;
+
+var bench = common.createBenchmark(main, {
+  len: [102400, 1024 * 1024 * 16],
+  type: ['utf', 'asc', 'buf'],
+  dur: [5],
+});
+
+var dur;
+var len;
+var type;
+var chunk;
+var encoding;
+
+function main(conf) {
+  dur = +conf.dur;
+  len = +conf.len;
+  type = conf.type;
+
+  switch (type) {
+    case 'buf':
+      chunk = new Buffer(len);
+      chunk.fill('x');
+      break;
+    case 'utf':
+      encoding = 'utf8';
+      chunk = new Array(len / 2 + 1).join('ü');
+      break;
+    case 'asc':
+      encoding = 'ascii';
+      chunk = new Array(len + 1).join('x');
+      break;
+    default:
+      throw new Error('invalid type: ' + type);
+      break;
+  }
+
+  server();
+}
+
+var net = require('net');
+
+function Writer() {
+  this.received = 0;
+  this.writable = true;
+}
+
+Writer.prototype.write = function(chunk, encoding, cb) {
+  this.received += chunk.length;
+
+  if (typeof encoding === 'function')
+    encoding();
+  else if (typeof cb === 'function')
+    cb();
+
+  return true;
+};
+
+// doesn't matter, never emits anything.
+Writer.prototype.on = function() {};
+Writer.prototype.once = function() {};
+Writer.prototype.emit = function() {};
+
+
+function Reader() {
+  this.flow = this.flow.bind(this);
+  this.readable = true;
+}
+
+Reader.prototype.pipe = function(dest) {
+  this.dest = dest;
+  this.flow();
+  return dest;
+};
+
+Reader.prototype.flow = function() {
+  var dest = this.dest;
+  var res = dest.write(chunk, encoding);
+  if (!res)
+    dest.once('drain', this.flow);
+  else
+    process.nextTick(this.flow);
+};
+
+
+function server() {
+  var reader = new Reader();
+  var writer = new Writer();
+
+  // the actual benchmark.
+  var server = net.createServer(function(socket) {
+    socket.pipe(writer);
+  });
+
+  server.listen(PORT, function() {
+    var socket = net.connect(PORT);
+    socket.on('connect', function() {
+      bench.start();
+
+      reader.pipe(socket);
+
+      setTimeout(function() {
+        var bytes = writer.received;
+        var gbits = (bytes * 8) / (1024 * 1024 * 1024);
+        bench.end(gbits);
+      }, dur * 1000);
+    });
+  });
+}

--- a/benchmark/net/net-pipe.js
+++ b/benchmark/net/net-pipe.js
@@ -1,0 +1,115 @@
+// test the speed of .pipe() with sockets
+
+var common = require('../common.js');
+var PORT = common.PORT;
+
+var bench = common.createBenchmark(main, {
+  len: [102400, 1024 * 1024 * 16],
+  type: ['utf', 'asc', 'buf'],
+  dur: [5],
+});
+
+var dur;
+var len;
+var type;
+var chunk;
+var encoding;
+
+function main(conf) {
+  dur = +conf.dur;
+  len = +conf.len;
+  type = conf.type;
+
+  switch (type) {
+    case 'buf':
+      chunk = new Buffer(len);
+      chunk.fill('x');
+      break;
+    case 'utf':
+      encoding = 'utf8';
+      chunk = new Array(len / 2 + 1).join('ü');
+      break;
+    case 'asc':
+      encoding = 'ascii';
+      chunk = new Array(len + 1).join('x');
+      break;
+    default:
+      throw new Error('invalid type: ' + type);
+      break;
+  }
+
+  server();
+}
+
+var net = require('net');
+
+function Writer() {
+  this.received = 0;
+  this.writable = true;
+}
+
+Writer.prototype.write = function(chunk, encoding, cb) {
+  this.received += chunk.length;
+
+  if (typeof encoding === 'function')
+    encoding();
+  else if (typeof cb === 'function')
+    cb();
+
+  return true;
+};
+
+// doesn't matter, never emits anything.
+Writer.prototype.on = function() {};
+Writer.prototype.once = function() {};
+Writer.prototype.emit = function() {};
+
+
+function Reader() {
+  this.flow = this.flow.bind(this);
+  this.readable = true;
+}
+
+Reader.prototype.pipe = function(dest) {
+  this.dest = dest;
+  this.flow();
+  return dest;
+};
+
+Reader.prototype.flow = function() {
+  var dest = this.dest;
+  var res = dest.write(chunk, encoding);
+  if (!res)
+    dest.once('drain', this.flow);
+  else
+    process.nextTick(this.flow);
+};
+
+
+function server() {
+  var reader = new Reader();
+  var writer = new Writer();
+
+  // the actual benchmark.
+  var server = net.createServer(function(socket) {
+    socket.pipe(socket);
+  });
+
+  server.listen(PORT, function() {
+    var socket = net.connect(PORT);
+    socket.on('connect', function() {
+      bench.start();
+
+      reader.pipe(socket);
+      socket.pipe(writer);
+
+      setTimeout(function() {
+        // multiply by 2 since we're sending it first one way
+        // then then back again.
+        var bytes = writer.received * 2;
+        var gbits = (bytes * 8) / (1024 * 1024 * 1024);
+        bench.end(gbits);
+      }, dur * 1000);
+    });
+  });
+}

--- a/benchmark/net/net-s2c.js
+++ b/benchmark/net/net-s2c.js
@@ -1,0 +1,112 @@
+// test the speed of .pipe() with sockets
+
+var common = require('../common.js');
+var PORT = common.PORT;
+
+var bench = common.createBenchmark(main, {
+  len: [102400, 1024 * 1024 * 16],
+  type: ['utf', 'asc', 'buf'],
+  dur: [5]
+});
+
+var dur;
+var len;
+var type;
+var chunk;
+var encoding;
+
+function main(conf) {
+  dur = +conf.dur;
+  len = +conf.len;
+  type = conf.type;
+
+  switch (type) {
+    case 'buf':
+      chunk = new Buffer(len);
+      chunk.fill('x');
+      break;
+    case 'utf':
+      encoding = 'utf8';
+      chunk = new Array(len / 2 + 1).join('ü');
+      break;
+    case 'asc':
+      encoding = 'ascii';
+      chunk = new Array(len + 1).join('x');
+      break;
+    default:
+      throw new Error('invalid type: ' + type);
+      break;
+  }
+
+  server();
+}
+
+var net = require('net');
+
+function Writer() {
+  this.received = 0;
+  this.writable = true;
+}
+
+Writer.prototype.write = function(chunk, encoding, cb) {
+  this.received += chunk.length;
+
+  if (typeof encoding === 'function')
+    encoding();
+  else if (typeof cb === 'function')
+    cb();
+
+  return true;
+};
+
+// doesn't matter, never emits anything.
+Writer.prototype.on = function() {};
+Writer.prototype.once = function() {};
+Writer.prototype.emit = function() {};
+
+
+function Reader() {
+  this.flow = this.flow.bind(this);
+  this.readable = true;
+}
+
+Reader.prototype.pipe = function(dest) {
+  this.dest = dest;
+  this.flow();
+  return dest;
+};
+
+Reader.prototype.flow = function() {
+  var dest = this.dest;
+  var res = dest.write(chunk, encoding);
+  if (!res)
+    dest.once('drain', this.flow);
+  else
+    process.nextTick(this.flow);
+};
+
+
+function server() {
+  var reader = new Reader();
+  var writer = new Writer();
+
+  // the actual benchmark.
+  var server = net.createServer(function(socket) {
+    reader.pipe(socket);
+  });
+
+  server.listen(PORT, function() {
+    var socket = net.connect(PORT);
+    socket.on('connect', function() {
+      bench.start();
+
+      socket.pipe(writer);
+
+      setTimeout(function() {
+        var bytes = writer.received;
+        var gbits = (bytes * 8) / (1024 * 1024 * 1024);
+        bench.end(gbits);
+      }, dur * 1000);
+    });
+  });
+}

--- a/benchmark/net/tcp-raw-c2s.js
+++ b/benchmark/net/tcp-raw-c2s.js
@@ -1,0 +1,136 @@
+// In this benchmark, we connect a client to the server, and write
+// as many bytes as we can in the specified time (default = 10s)
+
+var common = require('../common.js');
+
+// if there are --dur=N and --len=N args, then
+// run the function with those settings.
+// if not, then queue up a bunch of child processes.
+var bench = common.createBenchmark(main, {
+  len: [102400, 1024 * 1024 * 16],
+  type: ['utf', 'asc', 'buf'],
+  dur: [5]
+});
+
+var TCP = process.binding('tcp_wrap').TCP;
+var PORT = common.PORT;
+
+var dur;
+var len;
+var type;
+
+function main(conf) {
+  dur = +conf.dur;
+  len = +conf.len;
+  type = conf.type;
+  server();
+}
+
+
+function fail(syscall) {
+  var e = new Error(syscall + ' ' + errno);
+  e.errno = e.code = errno;
+  e.syscall = syscall;
+  throw e;
+}
+
+function server() {
+  var serverHandle = new TCP();
+  var r = serverHandle.bind('127.0.0.1', PORT);
+  if (r)
+    fail('bind');
+
+  var r = serverHandle.listen(511);
+  if (r)
+    fail('listen');
+
+  serverHandle.onconnection = function(clientHandle) {
+    if (!clientHandle)
+      fail('connect');
+
+    // the meat of the benchmark is right here:
+    bench.start();
+    var bytes = 0;
+
+    setTimeout(function() {
+      // report in Gb/sec
+      bench.end((bytes * 8) / (1024 * 1024 * 1024));
+    }, dur * 1000);
+
+    clientHandle.onread = function(buffer, offset, length) {
+      // we're not expecting to ever get an EOF from the client.
+      // just lots of data forever.
+      if (!buffer)
+        fail('read');
+
+      // don't slice the buffer.  the point of this is to isolate, not
+      // simulate real traffic.
+      // var chunk = buffer.slice(offset, offset + length);
+      bytes += length;
+    };
+
+    clientHandle.readStart();
+  };
+
+  client();
+}
+
+function client() {
+  var chunk;
+  switch (type) {
+    case 'buf':
+      chunk = new Buffer(len);
+      chunk.fill('x');
+      break;
+    case 'utf':
+      chunk = new Array(len / 2 + 1).join('ü');
+      break;
+    case 'asc':
+      chunk = new Array(len + 1).join('x');
+      break;
+    default:
+      throw new Error('invalid type: ' + type);
+      break;
+  }
+
+  var clientHandle = new TCP();
+  var connectReq = clientHandle.connect('127.0.0.1', PORT);
+
+  if (!connectReq)
+    fail('connect');
+
+  clientHandle.readStart();
+
+  connectReq.oncomplete = function() {
+    while (clientHandle.writeQueueSize === 0)
+      write();
+  };
+
+  function write() {
+    var writeReq
+    switch (type) {
+      case 'buf':
+        writeReq = clientHandle.writeBuffer(chunk);
+        break;
+      case 'utf':
+        writeReq = clientHandle.writeUtf8String(chunk);
+        break;
+      case 'asc':
+        writeReq = clientHandle.writeAsciiString(chunk);
+        break;
+    }
+
+    if (!writeReq)
+      fail('write');
+
+    writeReq.oncomplete = afterWrite;
+  }
+
+  function afterWrite(status, handle, req) {
+    if (status)
+      fail('write');
+
+    while (clientHandle.writeQueueSize === 0)
+      write();
+  }
+}

--- a/benchmark/net/tcp-raw-pipe.js
+++ b/benchmark/net/tcp-raw-pipe.js
@@ -1,0 +1,149 @@
+// In this benchmark, we connect a client to the server, and write
+// as many bytes as we can in the specified time (default = 10s)
+
+var common = require('../common.js');
+
+// if there are --dur=N and --len=N args, then
+// run the function with those settings.
+// if not, then queue up a bunch of child processes.
+var bench = common.createBenchmark(main, {
+  len: [102400, 1024 * 1024 * 16],
+  type: ['utf', 'asc', 'buf'],
+  dur: [5]
+});
+
+var TCP = process.binding('tcp_wrap').TCP;
+var PORT = common.PORT;
+
+var dur;
+var len;
+var type;
+
+function main(conf) {
+  dur = +conf.dur;
+  len = +conf.len;
+  type = conf.type;
+  server();
+}
+
+
+function fail(syscall) {
+  var e = new Error(syscall + ' ' + errno);
+  e.errno = e.code = errno;
+  e.syscall = syscall;
+  throw e;
+}
+
+function server() {
+  var serverHandle = new TCP();
+  var r = serverHandle.bind('127.0.0.1', PORT);
+  if (r)
+    fail('bind');
+
+  var r = serverHandle.listen(511);
+  if (r)
+    fail('listen');
+
+  serverHandle.onconnection = function(clientHandle) {
+    if (!clientHandle)
+      fail('connect');
+
+    clientHandle.onread = function(buffer, offset, length) {
+      // we're not expecting to ever get an EOF from the client.
+      // just lots of data forever.
+      if (!buffer)
+        fail('read');
+
+      var chunk = buffer.slice(offset, offset + length);
+      var writeReq = clientHandle.writeBuffer(chunk);
+
+      if (!writeReq)
+        fail('write');
+
+      writeReq.oncomplete = function(status, handle, req) {
+        if (status)
+          fail('write');
+      };
+    };
+
+    clientHandle.readStart();
+  };
+
+  client();
+}
+
+function client() {
+  var chunk;
+  switch (type) {
+    case 'buf':
+      chunk = new Buffer(len);
+      chunk.fill('x');
+      break;
+    case 'utf':
+      chunk = new Array(len / 2 + 1).join('ü');
+      break;
+    case 'asc':
+      chunk = new Array(len + 1).join('x');
+      break;
+    default:
+      throw new Error('invalid type: ' + type);
+      break;
+  }
+
+  var clientHandle = new TCP();
+  var connectReq = clientHandle.connect('127.0.0.1', PORT);
+  var bytes = 0;
+
+  if (!connectReq)
+    fail('connect');
+
+  clientHandle.readStart();
+
+  clientHandle.onread = function(buffer, start, length) {
+    if (!buffer)
+      fail('read');
+
+    bytes += length;
+  };
+
+  connectReq.oncomplete = function() {
+    bench.start();
+
+    setTimeout(function() {
+      // multiply by 2 since we're sending it first one way
+      // then then back again.
+      bench.end(2 * (bytes * 8) / (1024 * 1024 * 1024));
+    }, dur * 1000);
+
+    while (clientHandle.writeQueueSize === 0)
+      write();
+  };
+
+  function write() {
+    var writeReq
+    switch (type) {
+      case 'buf':
+        writeReq = clientHandle.writeBuffer(chunk);
+        break;
+      case 'utf':
+        writeReq = clientHandle.writeUtf8String(chunk);
+        break;
+      case 'asc':
+        writeReq = clientHandle.writeAsciiString(chunk);
+        break;
+    }
+
+    if (!writeReq)
+      fail('write');
+
+    writeReq.oncomplete = afterWrite;
+  }
+
+  function afterWrite(status, handle, req) {
+    if (status)
+      fail('write');
+
+    while (clientHandle.writeQueueSize === 0)
+      write();
+  }
+}

--- a/benchmark/net/tcp-raw-s2c.js
+++ b/benchmark/net/tcp-raw-s2c.js
@@ -1,0 +1,136 @@
+// In this benchmark, we connect a client to the server, and write
+// as many bytes as we can in the specified time (default = 10s)
+
+var common = require('../common.js');
+
+// if there are dur=N and len=N args, then
+// run the function with those settings.
+// if not, then queue up a bunch of child processes.
+var bench = common.createBenchmark(main, {
+  len: [102400, 1024 * 1024 * 16],
+  type: ['utf', 'asc', 'buf'],
+  dur: [5]
+});
+
+var TCP = process.binding('tcp_wrap').TCP;
+var PORT = common.PORT;
+
+var dur;
+var len;
+var type;
+
+function main(conf) {
+  dur = +conf.dur;
+  len = +conf.len;
+  type = conf.type;
+  server();
+}
+
+
+function fail(syscall) {
+  var e = new Error(syscall + ' ' + errno);
+  e.errno = e.code = errno;
+  e.syscall = syscall;
+  throw e;
+}
+
+function server() {
+  var serverHandle = new TCP();
+  var r = serverHandle.bind('127.0.0.1', PORT);
+  if (r)
+    fail('bind');
+
+  var r = serverHandle.listen(511);
+  if (r)
+    fail('listen');
+
+  serverHandle.onconnection = function(clientHandle) {
+    if (!clientHandle)
+      fail('connect');
+
+    var chunk;
+    switch (type) {
+      case 'buf':
+        chunk = new Buffer(len);
+        chunk.fill('x');
+        break;
+      case 'utf':
+        chunk = new Array(len / 2 + 1).join('ü');
+        break;
+      case 'asc':
+        chunk = new Array(len + 1).join('x');
+        break;
+      default:
+        throw new Error('invalid type: ' + type);
+        break;
+    }
+
+    clientHandle.readStart();
+
+    while (clientHandle.writeQueueSize === 0)
+      write();
+
+    function write() {
+      var writeReq
+      switch (type) {
+        case 'buf':
+          writeReq = clientHandle.writeBuffer(chunk);
+          break;
+        case 'utf':
+          writeReq = clientHandle.writeUtf8String(chunk);
+          break;
+        case 'asc':
+          writeReq = clientHandle.writeAsciiString(chunk);
+          break;
+      }
+
+      if (!writeReq)
+        fail('write');
+
+      writeReq.oncomplete = afterWrite;
+    }
+
+    function afterWrite(status, handle, req) {
+      if (status)
+        fail('write');
+
+      while (clientHandle.writeQueueSize === 0)
+        write();
+    }
+  };
+
+  client();
+}
+
+function client() {
+  var clientHandle = new TCP();
+  var connectReq = clientHandle.connect('127.0.0.1', PORT);
+
+  if (!connectReq)
+    fail('connect');
+
+  connectReq.oncomplete = function() {
+    var bytes = 0;
+    clientHandle.onread = function(buffer, offset, length) {
+      // we're not expecting to ever get an EOF from the client.
+      // just lots of data forever.
+      if (!buffer)
+        fail('read');
+
+      // don't slice the buffer.  the point of this is to isolate, not
+      // simulate real traffic.
+      // var chunk = buffer.slice(offset, offset + length);
+      bytes += length;
+    };
+
+    clientHandle.readStart();
+
+    // the meat of the benchmark is right here:
+    bench.start();
+
+    setTimeout(function() {
+      // report in Gb/sec
+      bench.end((bytes * 8) / (1024 * 1024 * 1024));
+    }, dur * 1000);
+  };
+}

--- a/benchmark/plot.R
+++ b/benchmark/plot.R
@@ -1,0 +1,86 @@
+#!/usr/bin/env Rscript
+
+# To use this script you'll need to install R: http://www.r-project.org/
+# and a library for R called ggplot2 
+# Which can be done by starting R and typing install.packages("ggplot2")
+# like this:
+#
+#     shell% R
+#     R version 2.11.0 beta (2010-04-12 r51689)
+#     >  install.packages("ggplot2")
+#     (follow prompt) 
+#
+# Then you can try this script by providing a full path to .data file
+# outputed from 'make bench'
+#
+#     > cd ~/src/node
+#     > make bench
+#     ...
+#     > ./benchmark/plot.R .benchmark_reports/ab-hello-world-buffer-1024/ff456b38862de3fd0118c6ac6b3f46edb1fbb87f/20101013162056.data
+#     
+# This will generate a PNG file which you can view
+#
+#
+# Hopefully these steps will be automated in the future.
+
+
+
+library(ggplot2)
+
+args <- commandArgs(TRUE)
+
+ab.load <- function (filename, name) {
+  raw <- data.frame(read.csv(filename, sep="\t", header=T), server=name)
+  raw <- data.frame(raw, time=raw$seconds-min(raw$seconds))
+  raw <- data.frame(raw, time_s=raw$time/1000000)
+  raw
+}
+
+#ab.tsPoint <- function (d) {
+#  qplot(time_s, ttime, data=d, facets=server~.,
+#        geom="point", alpha=I(1/15), ylab="response time (ms)",
+#        xlab="time (s)", main="c=30, res=26kb", 
+#        ylim=c(0,100))
+#}
+#
+#ab.tsLine <- function (d) {
+#  qplot(time_s, ttime, data=d, facets=server~.,
+#        geom="line", ylab="response time (ms)",
+#        xlab="time (s)", main="c=30, res=26kb", 
+#        ylim=c(0,100))
+#}
+
+
+filename <- args[0:1]
+data <- ab.load(filename, "node")
+
+
+# histogram
+
+#hist_png_filename <- gsub(".data", "_hist.png", filename)
+hist_png_filename <- "hist.png"
+
+png(filename = hist_png_filename, width = 480, height = 380, units = "px")
+
+qplot(ttime, data=data, geom="histogram",
+      main="xxx",
+      binwidth=1, xlab="response time (ms)",
+      xlim=c(0,100))
+
+print(hist_png_filename)
+
+
+
+# time series
+
+#ts_png_filename <- gsub(".data", "_ts.png", filename)
+ts_png_filename = "ts.png"
+
+png(filename = ts_png_filename, width = 480, height = 380, units = "px")
+
+qplot(time, ttime, data=data, facets=server~.,
+      geom="point", alpha=I(1/15), ylab="response time (ms)",
+      xlab="time (s)", main="xxx",
+      ylim=c(0,100))
+
+print(ts_png_filename)

--- a/benchmark/report-startup-memory.js
+++ b/benchmark/report-startup-memory.js
@@ -1,0 +1,1 @@
+console.log(process.memoryUsage().rss);

--- a/benchmark/static_http_server.js
+++ b/benchmark/static_http_server.js
@@ -1,0 +1,44 @@
+var http = require('http');
+
+var concurrency = 30;
+var port = 12346;
+var n = 700;
+var bytes = 1024*5;
+
+var requests = 0;
+var responses = 0;
+
+var body = '';
+for (var i = 0; i < bytes; i++) {
+  body += 'C';
+}
+
+var server = http.createServer(function(req, res) {
+  res.writeHead(200, {
+    'Content-Type': 'text/plain',
+    'Content-Length': body.length
+  });
+  res.end(body);
+})
+
+server.listen(port, function() {
+  var agent = new http.Agent();
+  agent.maxSockets = concurrency;
+
+  for (var i = 0; i < n; i++) {
+    var req = http.get({
+      port:  port,
+      path:  '/',
+      agent: agent
+    }, function(res) {
+      res.resume();
+      res.on('end', function() {
+        if (++responses === n) {
+          server.close();
+        }
+      });
+    });
+    req.id = i;
+    requests++;
+  }
+});

--- a/benchmark/tls/throughput.js
+++ b/benchmark/tls/throughput.js
@@ -1,0 +1,74 @@
+var common = require('../common.js');
+var bench = common.createBenchmark(main, {
+  dur: [5],
+  type: ['buf', 'asc', 'utf'],
+  size: [2, 1024, 1024 * 1024]
+});
+
+var dur, type, encoding, size;
+var server;
+
+var path = require('path');
+var fs = require('fs');
+var cert_dir = path.resolve(__dirname, '../../test/fixtures');
+var options;
+var tls = require('tls');
+
+function main(conf) {
+  dur = +conf.dur;
+  type = conf.type;
+  size = +conf.size;
+
+  var chunk;
+  switch (type) {
+    case 'buf':
+      chunk = new Buffer(size);
+      chunk.fill('b');
+      break;
+    case 'asc':
+      chunk = new Array(size + 1).join('a');
+      encoding = 'ascii';
+      break;
+    case 'utf':
+      chunk = new Array(size/2 + 1).join('ü');
+      encoding = 'utf8';
+      break;
+    default:
+      throw new Error('invalid type');
+  }
+
+  options = { key: fs.readFileSync(cert_dir + '/test_key.pem'),
+              cert: fs.readFileSync(cert_dir + '/test_cert.pem'),
+              ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ] };
+
+  server = tls.createServer(options, onConnection);
+  setTimeout(done, dur * 1000);
+  server.listen(common.PORT, function() {
+    var opt = { port: common.PORT, rejectUnauthorized: false };
+    var conn = tls.connect(opt, function() {
+      bench.start();
+      conn.on('drain', write);
+      write();
+    });
+
+    function write() {
+      var i = 0;
+      while (false !== conn.write(chunk, encoding));
+    }
+  });
+
+  var received = 0;
+  function onConnection(conn) {
+    conn.on('data', function(chunk) {
+      received += chunk.length;
+    });
+  }
+
+  function done() {
+    var mbits = (received * 8) / (1024 * 1024);
+    bench.end(mbits);
+    conn.destroy();
+    server.close();
+  }
+}
+

--- a/benchmark/tls/tls-connect.js
+++ b/benchmark/tls/tls-connect.js
@@ -1,0 +1,63 @@
+var assert = require('assert'),
+    fs = require('fs'),
+    path = require('path'),
+    tls = require('tls');
+
+var common = require('../common.js');
+var bench = common.createBenchmark(main, {
+  concurrency: [1, 10],
+  dur: [5]
+});
+
+var clientConn = 0;
+var serverConn = 0;
+var server;
+var dur;
+var concurrency;
+var running = true;
+
+function main(conf) {
+  dur = +conf.dur;
+  concurrency = +conf.concurrency;
+
+  var cert_dir = path.resolve(__dirname, '../../test/fixtures'),
+      options = { key: fs.readFileSync(cert_dir + '/test_key.pem'),
+                  cert: fs.readFileSync(cert_dir + '/test_cert.pem'),
+                  ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ] };
+
+  server = tls.createServer(options, onConnection);
+  server.listen(common.PORT, onListening);
+}
+
+function onListening() {
+  setTimeout(done, dur * 1000);
+  bench.start();
+  for (var i = 0; i < concurrency; i++)
+    makeConnection();
+}
+
+function onConnection(conn) {
+  serverConn++;
+}
+
+function makeConnection() {
+  var conn = tls.connect({ port: common.PORT,
+                           rejectUnauthorized: false }, function() {
+    clientConn++;
+    conn.on('error', function(er) {
+      console.error('client error', er);
+      throw er;
+    });
+    conn.end();
+    if (running) makeConnection();
+  });
+}
+
+function done() {
+  running = false;
+  // it's only an established connection if they both saw it.
+  // because we destroy the server somewhat abruptly, these
+  // don't always match.  Generally, serverConn will be
+  // the smaller number, but take the min just to be sure.
+  bench.end(Math.min(serverConn, clientConn));
+}


### PR DESCRIPTION
This is the benchmark suite from node pruned for things that didn't really seem specific enough to include for zones. Initially added this for my own curiosity. Not sure it's worth merging.

It might be helpful for development though. It was interesting to see using `NODE_DEBUG=zone` what is actually happening during the benchmarks. Looks like the setup in the benchmarks isn't really doing much at the moment.

`bench` will run the tests requiring the zone module, then the vanilla benchmarks without zones.

```
NODE_DEBUG=zone make bench
```