### PR TITLE
Fix EE issue

### DIFF
--- a/lib/node-lib/events.js
+++ b/lib/node-lib/events.js
@@ -256,7 +256,7 @@ EventEmitter.prototype.removeListener = function(type, listener) {
       (util.isFunction(list.listener) && list.listener === listener)) {
     delete this._events[type];
     // ZONE: clean the zone wrapper.
-    zoneRemoveWrappedListener(this, listener);
+    zoneRemoveWrappedListener(this, list);
     if (this._events.removeListener) {
       this.emit('removeListener', type, listener);
     }
@@ -273,15 +273,15 @@ EventEmitter.prototype.removeListener = function(type, listener) {
     if (position < 0)
       return this;
 
+    // ZONE: clean the zone wrapper.
+    zoneRemoveWrappedListener(this, list[position]);
+
     if (list.length === 1) {
       list.length = 0;
       delete this._events[type];
     } else {
       list.splice(position, 1);
     }
-
-    // ZONE: clean the zone wrapper.
-    zoneRemoveWrappedListener(this, listener);
 
     if (this._events.removeListener)
       this.emit('removeListener', type, listener);
@@ -462,7 +462,7 @@ function zoneRemoveAllWrappedListeners(emitter, type) {
 
   if (list === listener ||
      (util.isFunction(list.listener) && list.listener === listener)) {
-    zoneRemoveWrappedListener(emiiter, list);
+    zoneRemoveWrappedListener(emitter, list);
   } else if (util.isObject(list)) {
     for (var i = list.length - 1; i >= 0; i--)
       zoneRemoveWrappedListener(emitter, list[i]);
@@ -479,7 +479,7 @@ function zoneRemoveAllWrappedLocalListeners() {
 
   for (var key in events) {
     var list = events[key];
-
+ 
     if (util.isFunction(list)) {
       if (list.zone === zone)
           zoneRemoveWrappedListener(emitter, list);
@@ -493,6 +493,6 @@ function zoneRemoveAllWrappedLocalListeners() {
       }
     }
   }
-
+  
   assert(!emitter._gates[zone.id]);
 }


### PR DESCRIPTION
When listeners are explicitly removed with removeListener, the registration with the source zone isn't properly removed.

@kraman This is a bug fix against the "old" implementation. The fast implementation has the same issue but I couldn't figure out how to port the fix - do you have any suggestions?
