### PR TITLE
chore: update license in json for consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git://github.com/strongloop/zone.git"
   },
   "author": "",
-  "license": "CPAL-1.0 or http://strongloop.com/license",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/strongloop/zone/issues"
   },


### PR DESCRIPTION
Fixes #55 
Update `license` property in package.json to be consistent with [the license file](https://github.com/strongloop/zone/blob/master/LICENSE).